### PR TITLE
Remove invalid syntax from example code

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -331,7 +331,7 @@ cfaSignIn('google.com').subscribe(
  cfaSignIn('google.com').pipe(
  	mapUserToUserInfo(),
  ).subscribe(
-    (user: UserInfo) => console.log(user.displayName);
+    (user: UserInfo) => console.log(user.displayName)
  )
 ```
 


### PR DESCRIPTION
Remove semicolon in sign in example: invalid syntax