### PR TITLE
Add 'import FBSDKCoreKit' to example code

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -276,6 +276,10 @@ npm install --save capacitor-firebase-auth
 
     Facebook SDK >= 5.0.0
     ```
+      import FBSDKCoreKit
+    
+      ...
+    
       func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call


### PR DESCRIPTION
It was not clear from the readme that we should import this package. 
ApplicationDelegate and Settings are otherwise not available.