### PR TITLE
fix signout error call for capacitor 2.0

### DIFF
--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -175,7 +175,7 @@ public class CapacitorFirebaseAuth: CAPPlugin {
             call.success()
         } catch let signOutError as NSError {
             print ("Error signing out: %@", signOutError)
-            call.reject("Error signing out: %@", signOutError)
+            call.reject("Error signing out: \(signOutError)")
         }
     }
 }


### PR DESCRIPTION
Hey!
Thanks for the library, I've been using for about 6 months now!
I just updated my app to Capacitor 2.0 and they seemed to have changed a call signature for the `call.reject` function you are using to in the catch of `signout` ? #66 
It seems like you were just wanting a template string for the error? I think perhaps it was using `signOutError` as the second argument in the function instead. 
I used string interpolation instead and I think that fixes it and still makes it compatible with old and new capacitor.

I don't program at all in swift, so this is my best guess... However, this change makes it work in my app 🤷‍♂ 
Thanks again!