### PR TITLE
Fixed a compatibility issue with Capacitor 2.2.0 where Config does not contain any static methods

### DIFF
--- a/android/capacitor-firebase-auth/src/main/java/com/baumblatt/capacitor/firebase/auth/CapacitorFirebaseAuth.java
+++ b/android/capacitor-firebase-auth/src/main/java/com/baumblatt/capacitor/firebase/auth/CapacitorFirebaseAuth.java
@@ -51,9 +51,9 @@ public class CapacitorFirebaseAuth extends Plugin {
 
         getConfigValue("nada");
 
-        String[] providers = Config.getArray(CONFIG_KEY_PREFIX+"providers", new String[0]);
-        this.nativeAuth = Config.getBoolean(CONFIG_KEY_PREFIX+"nativeAuth", false);
-        String languageCode = Config.getString(CONFIG_KEY_PREFIX+"languageCode", "en");
+        String[] providers = getBridge().getConfig().getArray(CONFIG_KEY_PREFIX+"providers", new String[0]);
+        this.nativeAuth = getBridge().getConfig().getBoolean(CONFIG_KEY_PREFIX+"nativeAuth", false);
+        String languageCode = getBridge().getConfig().getString(CONFIG_KEY_PREFIX+"languageCode", "en");
 
         // FirebaseApp is not initialized in this process - Error #1
         Log.d(PLUGIN_TAG, "Verifying if the default FirebaseApp was initialized.");

--- a/android/capacitor-firebase-auth/src/main/java/com/baumblatt/capacitor/firebase/auth/handlers/GoogleProviderHandler.java
+++ b/android/capacitor-firebase-auth/src/main/java/com/baumblatt/capacitor/firebase/auth/handlers/GoogleProviderHandler.java
@@ -39,7 +39,7 @@ public class GoogleProviderHandler implements ProviderHandler, GoogleApiClient.O
     public void init(CapacitorFirebaseAuth plugin) {
         this.plugin = plugin;
 
-        String[] permissions = Config.getArray(CONFIG_KEY_PREFIX + "permissions.google", new String[0]);
+        String[] permissions = plugin.getBridge().getConfig().getArray(CONFIG_KEY_PREFIX + "permissions.google", new String[0]);
 
         GoogleApiAvailability googleAPI = GoogleApiAvailability.getInstance();
         int result = googleAPI.isGooglePlayServicesAvailable(this.plugin.getContext());


### PR DESCRIPTION
You can view the change in the change log:
https://github.com/ionic-team/capacitor/blob/master/CHANGELOG.md#220-2020-06-10

specifically:
"feat(android): move Config to be per-instance rather than a singleton (#3055) (b4815a5), closes #3055"
