### PR TITLE
Fix version 2.2.1 not compiling: Update to the new Capacitor Config Class

### DIFF
--- a/android/src/main/java/com/baumblatt/capacitor/firebase/auth/CapacitorFirebaseAuth.java
+++ b/android/src/main/java/com/baumblatt/capacitor/firebase/auth/CapacitorFirebaseAuth.java
@@ -12,7 +12,7 @@ import com.baumblatt.capacitor.firebase.auth.handlers.GoogleProviderHandler;
 import com.baumblatt.capacitor.firebase.auth.handlers.PhoneProviderHandler;
 import com.baumblatt.capacitor.firebase.auth.handlers.ProviderHandler;
 import com.baumblatt.capacitor.firebase.auth.handlers.TwitterProviderHandler;
-import com.getcapacitor.Config;
+import com.getcapacitor.CapConfig;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
@@ -44,16 +44,16 @@ public class CapacitorFirebaseAuth extends Plugin {
 
     private boolean nativeAuth = false;
 
-    private Config config;
+    private CapConfig config;
 
-    public Config getConfig() {
+    public CapConfig getConfig() {
         return this.config;
     }
 
     public void load() {
         super.load();
 
-        this.config = new Config(this.bridge.getActivity().getAssets(), null);
+        this.config = new CapConfig(this.bridge.getActivity().getAssets(), null);
 
         String[] providers = this.config.getArray(CONFIG_KEY_PREFIX+"providers", new String[0]);
         this.nativeAuth = this.config.getBoolean(CONFIG_KEY_PREFIX+"nativeAuth", false);


### PR DESCRIPTION
Current capacitor version 2.2.1 deprecated `Config` class replacing it with `CapConfig` making the project not compiling.

This fix changes the usages of `Config` in replacement of the new `CapConfig` class.