### PR TITLE
refactor: unify firebase imports to recommended syntax

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -343,7 +343,8 @@ cfaSignInPhoneOnCodeReceived().subscribe(
 Suggestion for web authentication code to iOS, the ```verificationCode`` must be provided by the user, please see [Firebase documentation](https://firebase.google.com/docs/auth/web/phone-auth#sign-in-the-user-with-the-verification-code) for better options.
 ```typescript
 
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
 
 const credential = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
 
@@ -389,7 +390,7 @@ cfaSignInTwitter().subscribe(
 #### Sign In;  Use credentials for something; and map to UserInfo
 
 ```typescript
-import {UserInfo} from 'firebase'; 
+import {UserInfo} from 'firebase/app'; 
 import {cfaSignInTwitter, TwitterSignInResult, mapUserCredentialToUserInfo} from 'capacitor-firebase-auth/alternative'; 
 import {tap} from 'rxjs/operators';
 

--- a/src/facades.ts
+++ b/src/facades.ts
@@ -1,5 +1,5 @@
 import { registerWebPlugin, Plugins, Capacitor } from '@capacitor/core';
-import firebase from 'firebase/app';
+import * as firebase from 'firebase/app';
 import 'firebase/auth';
 import { Observable, throwError } from 'rxjs';
 import {

--- a/src/providers/twitter.provider.ts
+++ b/src/providers/twitter.provider.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import 'firebase/auth';
 import {SignInOptions, TwitterSignInResult} from '../definitions';
 import OAuthCredential = firebase.auth.OAuthCredential;

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,5 +1,6 @@
 import {registerWebPlugin, WebPlugin} from '@capacitor/core';
-import firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
 import {CapacitorFirebaseAuthPlugin, SignInResult} from './definitions';
 import {facebookSignInWeb} from './providers/facebook.provider';
 import {googleSignInWeb} from './providers/google.provider';


### PR DESCRIPTION
@baumblatt some older syntax of how Firebase is imported was remaining in your codebase resulting in the plugin importing the entire development build instead of just the core & auth modules.

This should fix warnings like these that were coming from your plugin:

<img width="687" alt="Screenshot 2020-07-18 09 57 58" src="https://user-images.githubusercontent.com/3253920/87840957-31612880-c8dd-11ea-89f3-91d2ea74ff79.png">


Fixes #100