### PR TITLE
Update facebook.provider.ts

### DIFF
--- a/src/providers/facebook.provider.ts
+++ b/src/providers/facebook.provider.ts
@@ -11,5 +11,5 @@ export const facebookSignInWeb: (options: {providerId: string, data?: SignInOpti
     const userCredential = await firebase.auth().signInWithPopup(provider);
 
     const {credential}: { credential: OAuthCredential; } = userCredential;
-    return new FacebookSignInResult(credential.idToken);
+    return new FacebookSignInResult(credential.accessToken);
 }


### PR DESCRIPTION
wrong credential since that using wrong idToken, leading to error. I guest this could be  copy typo

### Description
![image](https://user-images.githubusercontent.com/16970990/89372179-ab801280-d70f-11ea-9344-9ecb561ae9d9.png)

Close this issue: https://github.com/baumblatt/capacitor-firebase-auth/issues/103

### Change
Follow the document, I make this change from `idToken` to `.accessToken`

![image](https://user-images.githubusercontent.com/16970990/89372144-90ad9e00-d70f-11ea-93b7-b55ea3551a21.png)

https://firebase.google.com/docs/auth/web/facebook-login
