### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -152,6 +152,11 @@ npm install --save capacitor-firebase-auth
     * Open your project configuration: double-click the project name in the left tree view. Select your app from the **TARGETS** section, then select the **Info** tab, and expand the **URL Types** section.
     * Click the **+** button, and add a `URL scheme` for your reversed client ID. To find this value, open the `GoogleService-Info.plist` configuration file, and look for the `REVERSED_CLIENT_ID` key. Copy the value of that key, and paste it into the **URL Schemes** box on the configuration page. Leave the other fields blank.
 
+## Phone
+
+#### Google iOS specific configurations
+Since that Apple using Push Notification service (APNs). You need to have `.p8` key and upload to project FCM config to use phone login or you will get this [Error](https://stackoverflow.com/questions/45091583/invalid-token-when-trying-to-authenticate-phone-number-using-firebase). Do so from the [Settings page](https://console.firebase.google.com/project/_/settings/cloudmessaging/) of the Firebase console. See [Configuring APNs with FCM](https://firebase.google.com/docs/cloud-messaging/ios/certs) for details on how to get your app's P8 key.
+
 ## Twitter
 
 #### Twitter global configurations


### PR DESCRIPTION
Add instruction for the phone login if user forget to enable APNs.
# Description
Since that I'm release an small checkin app but the Apple keep reject me few times:
1) first time is because I'm not enable APNs service in the application
2) second time is because the token not valid, I try to understand and get this [Error](https://stackoverflow.com/questions/45091583/invalid-token-when-trying-to-authenticate-phone-number-using-firebase) this man have the same issue

# Expect Behavior
phone login should work correctly

# Current behavior 
I got this error message on the xcode log:
```
ERROR MESSAGE:  {"message":"PhoneAuth Sign In failure: Error Domain=FIRAuthErrorDomain Code=17048 \"Invalid token.\" UserInfo={NSLocalizedDescription=Invalid token., FIRAuthErrorUserInfoNameKey=INVALID_APP_CREDENTIAL}","errorMessage":""}
⚡️  [error] - mobilePhoneLogin error: {"message":"PhoneAuth Sign In failure: Error Domain=FIRAuthErrorDomain Code=17048 \"Invalid token.\" UserInfo={NSLocalizedDescription=Invalid token., FIRAuthErrorUserInfoNameKey=INVALID_APP_CREDENTIAL}","errorMessage":""}
```

# Solution:

warning about people that they should enable APNs and generate `.p8` key then upload to firebase config to enable to login with phone from iOS

