### PR TITLE
Fix missing Apple Sign in on the general `cfaSignIn` method

### DIFF
--- a/src/alternative/alternative.ts
+++ b/src/alternative/alternative.ts
@@ -33,6 +33,8 @@ export const cfaSignIn = (providerId: string, data?: SignInOptions): Observable<
 			return cfaSignInTwitter();
 		case facebookProvider:
 			return cfaSignInFacebook();
+	        case cfaSignInAppleProvider:
+        		return cfaSignInApple();
 		case phoneProvider:
 			return cfaSignInPhone(data.phone, data.verificationCode);
 		default:


### PR DESCRIPTION
Using the alternative methods, the general `cfaSignIn` is missing support for OAuth provider `apple.com`.