### PR TITLE
PhoneProvider consistency between IOS and Android

### DIFF
--- a/android/src/main/java/com/baumblatt/capacitor/firebase/auth/handlers/PhoneProviderHandler.java
+++ b/android/src/main/java/com/baumblatt/capacitor/firebase/auth/handlers/PhoneProviderHandler.java
@@ -46,9 +46,7 @@ public class PhoneProviderHandler implements ProviderHandler {
 
                 JSObject jsUser = new JSObject();
                 jsUser.put("callbackId", call.getCallbackId());
-                jsUser.put("providerId", credential.getProvider());
                 jsUser.put("verificationId", mVerificationId);
-                jsUser.put("verificationCode", mVerificationCode);
 
                 call.success(jsUser);
             }


### PR DESCRIPTION
Today in IOS the verification code is not sent in the signIn callback. This means that the user is not authenticated on javascript and allow the user to link to an existing account or sign in (like example).
In android we can have the validation code, and it will directly signIn the user and cancel the possibility to link phone number with an existing account.

To keep consistency between ios and android we should send the same information / do the same thing.

As this is a breaking changes it could be added in v3 if you are ok with this.