### PR TITLE
Streamlined Provider ID retrieval

### DIFF
--- a/src/alternative/alternative.ts
+++ b/src/alternative/alternative.ts
@@ -15,10 +15,10 @@ import {
  * @param data The provider additional information (optional).
  */
 export const cfaSignIn = (providerId: string, data?: SignInOptions): Observable<{ userCredential: firebase.auth.UserCredential, result: SignInResult }> => {
-	const googleProvider = new firebase.auth.GoogleAuthProvider().providerId;
-	const facebookProvider = new firebase.auth.FacebookAuthProvider().providerId;
-	const twitterProvider = new firebase.auth.TwitterAuthProvider().providerId;
-	const phoneProvider = new firebase.auth.PhoneAuthProvider().providerId;
+	const googleProvider = firebase.auth.GoogleAuthProvider.PROVIDER_ID;
+	const facebookProvider = firebase.auth.FacebookAuthProvider.PROVIDER_ID;
+	const twitterProvider = firebase.auth.TwitterAuthProvider.PROVIDER_ID;
+	const phoneProvider = firebase.auth.PhoneAuthProvider.PROVIDER_ID;
 	switch (providerId) {
 		case googleProvider:
 			return cfaSignInGoogle();

--- a/src/facades.ts
+++ b/src/facades.ts
@@ -20,10 +20,10 @@ const plugin: CapacitorFirebaseAuthPlugin = CapacitorFirebaseAuth;
  * @param data The provider additional information (optional).
  */
 export const cfaSignIn = (providerId: string, data?: SignInOptions): Observable<firebase.User> => {
-	const googleProvider = new firebase.auth.GoogleAuthProvider().providerId;
-	const facebookProvider = new firebase.auth.FacebookAuthProvider().providerId;
-	const twitterProvider = new firebase.auth.TwitterAuthProvider().providerId;
-	const phoneProvider = new firebase.auth.PhoneAuthProvider().providerId;
+	const googleProvider = firebase.auth.GoogleAuthProvider.PROVIDER_ID;
+	const facebookProvider = firebase.auth.FacebookAuthProvider.PROVIDER_ID;
+	const twitterProvider = firebase.auth.TwitterAuthProvider.PROVIDER_ID;
+	const phoneProvider = firebase.auth.PhoneAuthProvider.PROVIDER_ID;
 	switch (providerId) {
 		case googleProvider:
 			return cfaSignInGoogle();

--- a/src/web.ts
+++ b/src/web.ts
@@ -18,10 +18,10 @@ export class CapacitorFirebaseAuthWeb extends WebPlugin implements CapacitorFire
 
   async signIn<T extends SignInResult>(options: { providerId: string, data?: SignInOptions }): Promise<T> {
       const appleProvider = 'apple.com';
-      const googleProvider = new firebase.auth.GoogleAuthProvider().providerId;
-      const facebookProvider = new firebase.auth.FacebookAuthProvider().providerId;
-      const twitterProvider = new firebase.auth.TwitterAuthProvider().providerId;
-      const phoneProvider = new firebase.auth.PhoneAuthProvider().providerId;
+      const googleProvider = firebase.auth.GoogleAuthProvider.PROVIDER_ID;
+      const facebookProvider = firebase.auth.FacebookAuthProvider.PROVIDER_ID;
+      const twitterProvider = firebase.auth.TwitterAuthProvider.PROVIDER_ID;
+      const phoneProvider = firebase.auth.PhoneAuthProvider.PROVIDER_ID;
       
       switch (options.providerId) {
           case appleProvider:


### PR DESCRIPTION
I realized that provider IDs are sourced differently at different places in the code. The change streamlines the retrieval of provider IDs and now always uses the static `PROVIDER_ID` property instead of the object property `providerId`:

Old:
`new firebase.auth.GoogleAuthProvider().providerId`

New:
`firebase.auth.GoogleAuthProvider.PROVIDER_ID`