### PR TITLE
Fix error for iOS facebook login

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -292,6 +292,19 @@ Since that Apple using Push Notification service (APNs). You need to have `.p8` 
     
       ...
     
+      func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+
+        ApplicationDelegate.shared.application(
+            application,
+            didFinishLaunchingWithOptions: launchOptions
+        )
+        
+        return true
+      }
+
+      ...
+    
       func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call


### PR DESCRIPTION
The below error occurs when attempting auth using Facebook on iOS, when using FBSDK pods version > 9.1.0

"App ID not found. Add a string value with your app ID for the key FacebookAppID to the Info.plist or call [FBSDKSettings setAppID:]"

More detail about the error and fix here:
https://github.com/facebook/facebook-ios-sdk/issues/1745#issuecomment-848180151