### PR TITLE
implement phone code resending on android

### DIFF
--- a/android/src/main/java/com/baumblatt/capacitor/firebase/auth/handlers/PhoneProviderHandler.java
+++ b/android/src/main/java/com/baumblatt/capacitor/firebase/auth/handlers/PhoneProviderHandler.java
@@ -103,8 +103,17 @@ public class PhoneProviderHandler implements ProviderHandler {
 
         String code = data.getString("verificationCode", "");
         if(code.equalsIgnoreCase("null") || code.equalsIgnoreCase("")) {
-            PhoneAuthProvider.getInstance().verifyPhoneNumber
+            Boolean resendToken = data.getBoolean("resendToken", false);
+            if (resendToken) {
+                Log.d(PHONE_TAG, "resend token");
+                PhoneAuthProvider.getInstance().verifyPhoneNumber
+                    (phone, 60, TimeUnit.SECONDS, this.plugin.getActivity(), this.mCallbacks,
+                    this.mResendToken);
+            } else {
+                Log.d(PHONE_TAG, "verify phone number");
+                PhoneAuthProvider.getInstance().verifyPhoneNumber
                     (phone, 60, TimeUnit.SECONDS, this.plugin.getActivity(), this.mCallbacks);
+            }
         } else {
             AuthCredential credential = PhoneAuthProvider.getCredential(this.mVerificationId, code);
             this.mVerificationCode = code;

--- a/src/alternative/alternative.ts
+++ b/src/alternative/alternative.ts
@@ -29,7 +29,7 @@ export const cfaSignIn = (providerId: string, data?: SignInOptions): Observable<
 		case cfaSignInAppleProvider:
 			return cfaSignInApple();
 		case phoneProvider:
-			return cfaSignInPhone(data?.phone as string, data?.verificationCode as string);
+			return cfaSignInPhone(data?.phone as string, data?.verificationCode as string, data?.resendToken as boolean);
 		default:
 			return throwError(new Error(`The '${providerId}' provider was not supported`));
 	}
@@ -154,13 +154,14 @@ export const cfaSignInApple = (): Observable<{ userCredential: firebase.auth.Use
  * This implementation is just to keep everything in compliance if others providers in this alternative calls.
  * @param phone The user phone number.
  * @param verificationCode The verification code sent by SMS (optional).
+ * @param resendToken Whether a verification code should be re-sent (optional)
  */
-export const cfaSignInPhone = (phone: string, verificationCode?: string): Observable<{ userCredential: firebase.auth.UserCredential, result: PhoneSignInResult }> => {
+export const cfaSignInPhone = (phone: string, verificationCode?: string, resendToken?: boolean): Observable<{ userCredential: firebase.auth.UserCredential, result: PhoneSignInResult }> => {
 	return new Observable(observer => {
 		// get the provider id
 		const providerId = firebase.auth.PhoneAuthProvider.PROVIDER_ID;
 
-		CapacitorFirebaseAuth.signIn<PhoneSignInResult>({ providerId, data: { phone, verificationCode } }).then((result: PhoneSignInResult) => {
+		CapacitorFirebaseAuth.signIn<PhoneSignInResult>({ providerId, data: { phone, verificationCode, resendToken } }).then((result: PhoneSignInResult) => {
 			// if there is no verification code
 			if (!result.verificationCode) {
 				return observer.complete();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -43,7 +43,8 @@ export class PhoneSignInResult implements SignInResult {
 export interface PhoneSignInOptions {
   container?: HTMLElement
   phone: string,
-  verificationCode?: string
+  verificationCode?: string,
+  resendToken?: boolean
 }
 
 export type SignInOptions = PhoneSignInOptions;

--- a/src/facades.ts
+++ b/src/facades.ts
@@ -37,7 +37,7 @@ export const cfaSignIn = (providerId: string, data?: SignInOptions): Observable<
 			if (!data) {
 				throw new Error('Phone and Verification data must be provided.')
 			}
-			return cfaSignInPhone(data.phone, data.verificationCode);
+			return cfaSignInPhone(data.phone, data.verificationCode, data.resendToken);
 		default:
 			return throwError(new Error(`The '${providerId}' provider was not supported`));
 	}
@@ -165,13 +165,14 @@ export const cfaSignInApple = (): Observable<firebase.User> => {
  * Call the Phone verification sign in, handling send and retrieve to code on native, but only sign in on web with retrieved credentials.
  * @param phone The user phone number.
  * @param verificationCode The verification code sent by SMS (optional).
+ * @param resendToken Whether a verification code should be re-sent (optional)
  */
-export const cfaSignInPhone = (phone: string, verificationCode?: string): Observable<firebase.User> => {
+export const cfaSignInPhone = (phone: string, verificationCode?: string, resendToken?: boolean): Observable<firebase.User> => {
 	return new Observable(observer => {
 		// get the provider id
 		const providerId = firebase.auth.PhoneAuthProvider.PROVIDER_ID;
 
-		plugin.signIn<PhoneSignInResult>({ providerId, data: { phone, verificationCode } }).then((result: PhoneSignInResult) => {
+		plugin.signIn<PhoneSignInResult>({ providerId, data: { phone, verificationCode, resendToken } }).then((result: PhoneSignInResult) => {
 			// if there is no verification code
 			if (!result.verificationCode) {
 				return observer.complete();


### PR DESCRIPTION
This PR implements re-sending of phone code according to https://firebase.google.com/docs/auth/android/phone-auth on Android.

On ios, it appears that no dedicated functionality for resending code is available --> `cfaSignInPhone` just works as normal