### PR TITLE
Update PhoneNumberProvider.swift

### DIFF
--- a/ios/Plugin/Handlers/PhoneNumberProvider.swift
+++ b/ios/Plugin/Handlers/PhoneNumberProvider.swift
@@ -31,7 +31,8 @@ class PhoneNumberProviderHandler: NSObject, ProviderHandler {
 
         PhoneAuthProvider.provider().verifyPhoneNumber(phone, uiDelegate: nil) { (verificationID, error) in
             if let error = error {
-                if let errCode = AuthErrorCode(rawValue: error._code) {
+                let nsError = error as NSError
+                if let errCode = AuthErrorCode.Code.init(rawValue: nsError.code) {
                     switch errCode {
                     case AuthErrorCode.quotaExceeded:
                         call.reject("Quota exceeded.")


### PR DESCRIPTION
Fixed `AuthErrorCode` Handling as cause following errors:
1. extraneous argument label 'rawValue:' in call
2. cannot convert value of type 'Int' to expected argument type 'AuthErrorCode.Code'